### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,8 @@ jobs:
           name: Tests
           command: |
             export HELM_HOME=''
-            npx bats -F bats-format-junit --extra-flags -T tests/*.bats
             mkdir -p tests/junit
-            mv TestReport-.xml tests/junit/results.xml
+            npx bats -F bats-format-junit  --output tests/junit --extra-flags -T tests/*.bats
 
       - store_test_results:
           path: tests/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,12 @@ jobs:
           name: Tests
           command: |
             export HELM_HOME=''
+            npx bats -F bats-format-junit --extra-flags -T tests/*.bats
             mkdir -p tests/junit
-            npx bats -F bats-format-junit --extra-flags -T --output tests/junit tests/*.bats
+            mv TestReport-.xml tests/junit/results.xml
 
       - store_test_results:
-          path: tests/xunit
+          path: tests/junit
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
           name: Tests
           command: |
             export HELM_HOME=''
-            mkdir -p tests/xunit
-            npm run --silent test:ci > tests/xunit/results.xml
+            mkdir -p tests/junit
+            npx bats -F bats-format-junit --extra-flags -T --output tests/junit tests/*.bats
 
       - store_test_results:
           path: tests/xunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-tests/xunit/
+tests/junit/

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ to the plugin, please see [these instructions](.github/CONTRIBUTING.md).
 
 Here's the Git urls format, followed by examples:
 
-    git+https://[provider.com]/[user]/[repo]//[path/to/charts]?ref=[git-ref]
-    git+ssh://git@[provider.com]/[user]/[repo]//[path/to/charts]?ref=[git-ref]
+    git+https://[provider.com]/[user]/[repo]@[path/to/charts]?ref=[git-ref]
+    git+ssh://git@[provider.com]/[user]/[repo]@[path/to/charts]?ref=[git-ref]
 
-    git+https://github.com/jetstack/cert-manager//contrib/charts?ref=v0.5.2
-    git+ssh://git@github.com/jetstack/cert-manager//contrib/charts?ref=v0.5.2
+    git+https://github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2
+    git+ssh://git@github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2
 
 Add your repository:
 
-    $ helm repo add cert-manager git+https://github.com/jetstack/cert-manager//contrib/charts?ref=v0.5.2
+    $ helm repo add cert-manager git+https://github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2
 
 You can use it as any other Helm chart repository. Try:
 
@@ -55,8 +55,8 @@ You can use it as any other Helm chart repository. Try:
 
 Fetching also works:
 
-    $ helm fetch cert-manager/cert-manager
-    $ helm fetch git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager-0.5.2.tgz?ref=v0.5.2
+    $ helm fetch cert-manager/cert-manager --version "0.5.2"
+    $ helm fetch git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-0.5.2.tgz?ref=v0.5.2
 
 ### Note on Git authentication
 

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -12,6 +12,7 @@ readonly error_invalid_prefix="Git url should start with '$url_prefix'. Please c
 readonly error_invalid_protocol="Protocol not allowed, it should match one of theses: $allowed_protocols."
 
 debug=0
+[ "$HELM_GIT_DEBUG" = "1" ] && debug=1
 
 ## Tooling
 
@@ -40,8 +41,7 @@ stashdir_init() {
   readonly stashdir_list_file=$(mktemp -p "$TMPDIR" 'helm-git.stash.XXXXXX')
   stashdir_clean_skip=$debug
 
-  # Test env
-  if [ -z "$BATS_TEST_DIRNAME" ]; then
+  if [ $debug = 0 ]; then
     trap stashdir_clean EXIT
   fi
 }

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -144,7 +144,9 @@ helm_inspect_name() {
 # main(raw_uri)
 main() {
   helm_args="" # "$1 $2 $3"
-  _raw_uri=$4 # eg: git+https://git.com/user/repo//path/to/charts/index.yaml?ref=master
+  _raw_uri=$4 # eg: git+https://git.com/user/repo@path/to/charts/index.yaml?ref=master
+
+  [ $debug = 1 ] && echo "input:$_raw_uri" >&2
 
   string_starts "$_raw_uri" "$url_prefix" || \
     error "Invalid format, got '$_raw_uri'. $error_invalid_prefix"
@@ -155,13 +157,13 @@ main() {
   string_contains "$allowed_protocols" "$git_proto" || \
     error "$error_invalid_protocol"
 
-  readonly git_repo=$(echo "$_raw_uri" | sed -r 's#^(.+)[^:]?\/{2}.*#\1#')
+  readonly git_repo=$(echo "$_raw_uri" | sed -r 's#^(.+)@.*#\1#')
   # TODO: Validate git_repo
 
-  readonly git_path=$(echo "$_raw_uri" | sed -r 's#.*[^:]?\/{2}(.*)\/.*#\1#')
+  readonly git_path=$(echo "$_raw_uri" | sed -r 's#.*@(.*)\/.*#\1#')
   # TODO: Validate git_path
 
-  readonly helm_file=$(echo "$_raw_uri" | sed -r 's#.*[^:]?\/{2}.*\/([^?]*).*#\1#')
+  readonly helm_file=$(echo "$_raw_uri" | sed -r 's#.*@.*\/([^?]*).*#\1#')
 
   git_ref=$(echo "$_raw_uri" | sed '/^.*ref=\([^&#]*\).*$/!d;s//\1/')
   # TODO: Validate git_ref
@@ -172,7 +174,7 @@ main() {
 
   [ $debug = 1 ] && echo "repo:$git_repo ref:$git_ref path:$git_path file:$helm_file" >&2
 
-  readonly helm_repo_uri="git+$git_repo//$git_path?ref=$git_ref"
+  readonly helm_repo_uri="git+$git_repo@$git_path?ref=$git_ref"
 
   stashdir_init
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -366,9 +366,8 @@
       }
     },
     "bats": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-1.1.0.tgz",
-      "integrity": "sha512-1pA29OhDByrUtAXX+nmqZxgRgx2y8PvuZzbLJVjd2dpEDVDvz0MjcBMdmIPNq5lC+tG53G+RbeRsbIlv3vw7tg==",
+      "version": "github:josegonzalez/bats-core#723a1fa83524f7e2b120eddd2ca5358ca5706b4f",
+      "from": "github:josegonzalez/bats-core#723a1fa83524f7e2b120eddd2ca5358ca5706b4f",
       "dev": true
     },
     "bignumber.js": {
@@ -850,12 +849,6 @@
         "rimraf": "^2.2.8"
       }
     },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
     "duplexify": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
@@ -956,12 +949,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "events-to-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
     "execa": {
@@ -2461,12 +2448,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
-    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -3632,32 +3613,6 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
-    "tap-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.2.2.tgz",
-      "integrity": "sha1-Xi9pcGEfB5x8+FfeHceqG0gN56U=",
-      "dev": true,
-      "requires": {
-        "events-to-array": "^1.0.1",
-        "inherits": "~2.0.1",
-        "js-yaml": "^3.2.7",
-        "readable-stream": "^2"
-      }
-    },
-    "tap-xunit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.3.0.tgz",
-      "integrity": "sha512-YVsURNvn1wfVUWb5wjansxhfbfeo2hOBTUbVgZoaMO8lyZzpiSi9IiZTZ7JG56m6A49LeWjfJIx/SnAre41V/A==",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "minimist": "~1.2.0",
-        "tap-parser": "~1.2.2",
-        "through2": "~2.0.0",
-        "xmlbuilder": "~4.2.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -4085,15 +4040,6 @@
       "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
       "integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ=",
       "dev": true
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.0"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "bats tests/*-*.bats",
     "test:e2e": "bats tests/e2e.bats",
-    "test:ci": "bats tests/*.bats | tap-xunit",
     "lint": "eclint check **/*; shellcheck 'helm-git' *.sh tests/*.bash"
   },
   "repository": {
@@ -19,12 +18,11 @@
   },
   "homepage": "https://github.com/aslafy-z/helm-git#readme",
   "devDependencies": {
-    "bats": "^1.1.0",
+    "bats": "github:josegonzalez/bats-core#723a1fa83524f7e2b120eddd2ca5358ca5706b4f",
     "eclint": "^2.8.1",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
-    "shellcheck": "^0.1.0",
-    "tap-xunit": "^2.3.0"
+    "shellcheck": "^0.1.0"
   },
   "husky": {
     "hooks": {

--- a/tests/01-git.bats
+++ b/tests/01-git.bats
@@ -7,9 +7,10 @@ load 'helm-git-helper'
 @test "git_sparse_checkout fail with non-existing path" {
   target_path=$(stashdir_new "fake git dir")
   git_repo="https://github.com/aslafy-z/helm-git"
-  git_ref="feat/full-refactor"
+  git_ref="master"
   git_path="tests/fixtures/non-existing-dir"
   run git_sparse_checkout "$target_path" "$git_repo" "$git_ref" "$git_path"
+  [ $status = 0 ]
   run stat "$target_path/$git_path/non-existing-file"
   [ $status = 1 ]
 }
@@ -17,9 +18,10 @@ load 'helm-git-helper'
 @test "git_sparse_checkout succeed with existing path" {
   target_path=$(stashdir_new "fake git dir")
   git_repo="https://github.com/aslafy-z/helm-git"
-  git_ref="feat/full-refactor"
+  git_ref="master"
   git_path="tests/fixtures/existing-dir"
   run git_sparse_checkout "$target_path" "$git_repo" "$git_ref" "$git_path"
+  [ $status = 0 ]
   run stat "$target_path/$git_path/existing-file"
   [ $status = 0 ]
 }

--- a/tests/01-git.bats
+++ b/tests/01-git.bats
@@ -10,8 +10,15 @@ load 'helm-git-helper'
   git_ref="master"
   git_path="tests/fixtures/non-existing-dir"
   run git_sparse_checkout "$target_path" "$git_repo" "$git_ref" "$git_path"
-  [ $status = 0 ]
-  run stat "$target_path/$git_path/non-existing-file"
+  [ $status = 1 ]
+}
+
+@test "git_sparse_checkout fail with non-existing ref" {
+  target_path=$(stashdir_new "fake git dir")
+  git_repo="https://github.com/aslafy-z/helm-git"
+  git_ref="this/ref/wont/ever/exist"
+  git_path="tests/fixtures/existing-dir"
+  run git_sparse_checkout "$target_path" "$git_repo" "$git_ref" "$git_path"
   [ $status = 1 ]
 }
 

--- a/tests/02-helm.bats
+++ b/tests/02-helm.bats
@@ -33,19 +33,19 @@ load 'helm-git-helper'
     [ $status = 1 ]
 }
 
-# helm_dep_update(target_path)
-@test "helm_dep_update success with example-chart" {
+# helm_dependency_update(target_path)
+@test "helm_dependency_update success with example-chart" {
     target_path=$(stashdir_new "test helm_package")
     cp -r "$BATS_TEST_DIRNAME/fixtures/example-chart" "$target_path"
-    run helm_dep_update "$target_path/example-chart"
+    run helm_dependency_update "$target_path/example-chart"
     [ $status = 0 ]
 }
 
-# helm_dep_update(target_path)
-@test "helm_dep_update fails with incorrect chart" {
+# helm_dependency_update(target_path)
+@test "helm_dependency_update fails with incorrect chart" {
     target_path=$(stashdir_new "test helm_package")
     cp -r "$BATS_TEST_DIRNAME/fixtures/existing-dir" "$target_path"
-    run helm_dep_update "$target_path/existing-dir"
+    run helm_dependency_update "$target_path/existing-dir"
     [ $status = 1 ]
 }
 

--- a/tests/03-cli.bats
+++ b/tests/03-cli.bats
@@ -4,7 +4,7 @@ load 'helm-git-helper'
 
 @test "fetch cert-manager/v0.5.2/index.yaml" {
     target_path=$(stashdir_new "cert-manager-v0.5.2")
-    url="git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager/index.yaml?ref=v0.5.2"
+    url="git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager/index.yaml?ref=v0.5.2"
     $HELM_GIT_DIRNAME/helm-git "" "" "" "$url" 2>/dev/null > "$target_path/index.yaml"
     [ $? = 0 ]
     run stat "$target_path/index.yaml"
@@ -14,7 +14,7 @@ load 'helm-git-helper'
 
 @test "fetch cert-manager/v0.5.2/cert-manager-v0.5.2.tgz" {
     target_path=$(stashdir_new "cert-manager-v0.5.2")
-    url="git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    url="git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager/cert-manager-v0.5.2.tgz?ref=v0.5.2"
     $HELM_GIT_DIRNAME/helm-git "" "" "" "$url" 2>/dev/null > "$target_path/cert-manager-v0.5.2.tgz"
     [ $? = 0 ]
     run stat "$target_path/cert-manager-v0.5.2.tgz"

--- a/tests/04-uri-validation.bats
+++ b/tests/04-uri-validation.bats
@@ -5,7 +5,7 @@ load 'helm-git-helper'
 function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
 
 @test "should fail with bad prefix" {
-    _run_helm_git "badprefix+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager/index.yaml?ref=v0.5.2"
+    _run_helm_git "badprefix+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager/index.yaml?ref=v0.5.2"
     [ $status = 1 ]
 }
 
@@ -20,23 +20,23 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
 }
 
 @test "should fail with bad protocol" {
-    _run_helm_git "git+unknown://github.com/jetstack/cert-manager/index.yaml?ref=master"
+    _run_helm_git "git+unknown://github.com/jetstack/cert-manager@index.yaml?ref=master"
     [ $status = 1 ]
 }
 
 @test "should fail with no protocol" {
-    _run_helm_git "git+git@github.com:toto/toto//index.yaml?ref=master"
+    _run_helm_git "git+git@github.com:toto/toto@index.yaml?ref=master"
     [ $status = 1 ]
 }
 
 @test "should fail and warning with bad path and no ref" {
-    _run_helm_git "git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager/index.yaml?ref="
+    _run_helm_git "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager/index.yaml?ref="
     [ $status = 1 ]
     [ -n "$(echo $output | grep "git_ref is empty")" ]
 }
 
 @test "should success and warning with no ref" {
-    _run_helm_git "git+https://github.com/jetstack/cert-manager//deploy/charts/index.yaml"
+    _run_helm_git "git+https://github.com/jetstack/cert-manager@deploy/charts/index.yaml"
     [ $status = 0 ]
     [ -n "$(echo $output | grep "git_ref is empty")" ]
 }

--- a/tests/05-helm-cli.bats
+++ b/tests/05-helm-cli.bats
@@ -9,7 +9,7 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     target_dir=$(stashdir_new "helm_cli fetch test")
     run helm_init "$HELM_HOME"
     run helm plugin install "$HELM_GIT_DIRNAME"
-    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager//contrib/charts/index.yaml?ref=v0.5.2"
+    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager@contrib/charts/index.yaml?ref=v0.5.2"
     run stat "$target_dir/index.yaml"
     [ $status = 0 ]
 }
@@ -21,7 +21,22 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     [ $status = 0 ]
     run helm plugin install "$HELM_GIT_DIRNAME"
     [ $status = 0 ]
-    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    run stat "$target_dir/cert-manager-v0.5.2.tgz"
+    [ $status = 0 ]
+}
+
+@test "helm_cli fetch cert-manager-v0.5.2.tgz relative" {
+    export HELM_HOME=$(stashdir_new "helm_home")
+    target_dir=$(stashdir_new "helm_cli fetch test")
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2"
+    [ $status = 0 ]
+    run helm fetch -d "$target_dir" "cert-manager/cert-manager-v0.5.2"
     [ $status = 0 ]
     run stat "$target_dir/cert-manager-v0.5.2.tgz"
     [ $status = 0 ]
@@ -34,7 +49,7 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     [ $status = 0 ]
     run helm plugin install "$HELM_GIT_DIRNAME"
     [ $status = 0 ]
-    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager//contrib/charts?ref=v0.5.2"
+    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2"
     [ $status = 0 ]
     run grep cert-manager-v0.5.2 "$HELM_HOME/repository/repositories.yaml"
     [ -n "$output" ]
@@ -47,7 +62,7 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     [ $status = 0 ]
     run helm plugin install "$HELM_GIT_DIRNAME"
     [ $status = 0 ]
-    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager?ref=v0.5.2"
+    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager?ref=v0.5.2"
     [ $status = 0 ]
     run grep cert-manager-v0.5.2 "$HELM_HOME/repository/repositories.yaml"
     [ -n "$output" ]

--- a/tests/05-helm-cli.bats
+++ b/tests/05-helm-cli.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load 'helm-git-helper'
+
+function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
+
+@test "helm_cli fetch index.yaml" {
+    export HELM_HOME=$(stashdir_new "helm_home")
+    target_dir=$(stashdir_new "helm_cli fetch test")
+    run helm_init "$HELM_HOME"
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager//contrib/charts/index.yaml?ref=v0.5.2"
+    run stat "$target_dir/index.yaml"
+    [ $status = 0 ]
+}
+
+@test "helm_cli fetch cert-manager-v0.5.2.tgz" {
+    export HELM_HOME=$(stashdir_new "helm_home")
+    target_dir=$(stashdir_new "helm_cli fetch test")
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run helm fetch -d "$target_dir" "git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    run stat "$target_dir/cert-manager-v0.5.2.tgz"
+    [ $status = 0 ]
+}
+
+@test "helm_cli repo_add cert-manager-v0.5.2 charts" {
+    export HELM_HOME=$(stashdir_new "helm_home")
+    target_dir=$(stashdir_new "helm_cli fetch test")
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager//contrib/charts?ref=v0.5.2"
+    [ $status = 0 ]
+    run grep cert-manager-v0.5.2 "$HELM_HOME/repository/repositories.yaml"
+    [ -n "$output" ]
+}
+
+@test "helm_cli repo_add cert-manager-v0.5.2 direct" {
+    export HELM_HOME=$(stashdir_new "helm_home")
+    target_dir=$(stashdir_new "helm_cli fetch test")
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager//contrib/charts/cert-manager?ref=v0.5.2"
+    [ $status = 0 ]
+    run grep cert-manager-v0.5.2 "$HELM_HOME/repository/repositories.yaml"
+    [ -n "$output" ]
+}

--- a/tests/05-helm-cli.bats
+++ b/tests/05-helm-cli.bats
@@ -36,7 +36,7 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     [ $status = 0 ]
     run helm repo add cert-manager-v0.5.2 "git+https://github.com/jetstack/cert-manager@contrib/charts?ref=v0.5.2"
     [ $status = 0 ]
-    run helm fetch -d "$target_dir" "cert-manager/cert-manager-v0.5.2"
+    run helm fetch -d "$target_dir" "cert-manager-v0.5.2/cert-manager"
     [ $status = 0 ]
     run stat "$target_dir/cert-manager-v0.5.2.tgz"
     [ $status = 0 ]

--- a/tests/e2e.bats
+++ b/tests/e2e.bats
@@ -9,7 +9,7 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     run helm_init "$HELM_HOME"
     helm repo add stable https://kubernetes-charts.storage.googleapis.com/ >/dev/null
     helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/ >/dev/null
-    run _run_helm_git "git+https://github.com/helm/charts//stable/index.yaml?ref=master"
+    run _run_helm_git "git+https://github.com/helm/charts@stable/index.yaml?ref=master"
     [ $status = 0 ]
 }
 
@@ -18,6 +18,6 @@ function _run_helm_git() { run $HELM_GIT_DIRNAME/helm-git '' '' '' "$1"; }
     run helm_init "$HELM_HOME"
     helm repo add stable https://kubernetes-charts.storage.googleapis.com/ >/dev/null
     helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/ >/dev/null
-    run _run_helm_git "git+https://github.com/helm/charts//incubator/index.yaml?ref=master"
+    run _run_helm_git "git+https://github.com/helm/charts@incubator/index.yaml?ref=master"
     [ $status = 0 ]
 }

--- a/tests/helm-git-helper.bash
+++ b/tests/helm-git-helper.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export HELM_GIT_DIRNAME="$BATS_TEST_DIRNAME/.."
+export HELM_GIT_DEBUG=1
 
 # shellcheck disable=SC1090
 source "$HELM_GIT_DIRNAME/helm-git-plugin.sh"


### PR DESCRIPTION
Fix #1 failing tests that passed with Github auto-merge

Had to switch back to @ as repo/path delimiter because `helm` stores modified url in cache (it cleans up empty `//` to `/`).  