### PR TITLE
OSX compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
               npm \
               git \
               curl # fix shellcheck
-            npm install
+            npm ci
 
       - run:
           name: Lint

--- a/helm-git
+++ b/helm-git
@@ -3,7 +3,8 @@
 # Small wrapper for helm downloader
 # Called with args: certFile keyFile caFile full-URL
 
-set -eo pipefail
+# shellcheck disable=SC2039
+set -e -o pipefail
 
 # cd to helm-git plugin folder
 cd "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)" >&2

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -2,7 +2,8 @@
 
 # See Helm plugins documentation: https://docs.helm.sh/using_helm/#downloader-plugins
 
-set -eo pipefail
+# shellcheck disable=SC2039
+set -e -o pipefail
 
 readonly bin_name="helm-git"
 readonly allowed_protocols="https http file ssh"

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -157,13 +157,13 @@ main() {
   string_contains "$allowed_protocols" "$git_proto" || \
     error "$error_invalid_protocol"
 
-  readonly git_repo=$(echo "$_raw_uri" | sed -r 's#^(.+)@.*#\1#')
+  readonly git_repo=$(echo "$_raw_uri" | sed -E 's#^(.+)@.*#\1#')
   # TODO: Validate git_repo
 
-  readonly git_path=$(echo "$_raw_uri" | sed -r 's#.*@(.*)\/.*#\1#')
+  readonly git_path=$(echo "$_raw_uri" | sed -E 's#.*@(.*)\/.*#\1#')
   # TODO: Validate git_path
 
-  readonly helm_file=$(echo "$_raw_uri" | sed -r 's#.*@.*\/([^?]*).*#\1#')
+  readonly helm_file=$(echo "$_raw_uri" | sed -E 's#.*@.*\/([^?]*).*#\1#')
 
   git_ref=$(echo "$_raw_uri" | sed '/^.*ref=\([^&#]*\).*$/!d;s//\1/')
   # TODO: Validate git_ref

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -39,7 +39,7 @@ export TMPDIR=${TMPDIR:-/tmp}
 
 # stashdir_init()
 stashdir_init() {
-  readonly stashdir_list_file=$(mktemp -p "$TMPDIR" 'helm-git.stash.XXXXXX')
+  readonly stashdir_list_file=$(mktemp 'helm-git.stash.XXXXXX')
   stashdir_clean_skip=$debug
 
   if [ $debug = 0 ]; then
@@ -51,7 +51,7 @@ stashdir_init() {
 stashdir_new() {
   _comment="$1"
 
-  new_dir=$(mktemp -p "$TMPDIR" -d 'helm-git.XXXXXX')
+  new_dir=$(mktemp -d 'helm-git.XXXXXX')
   echo "$new_dir" >> "$stashdir_list_file"
   echo "$new_dir"
   if [ $debug = 1 ]; then

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -39,7 +39,7 @@ export TMPDIR=${TMPDIR:-/tmp}
 
 # stashdir_init()
 stashdir_init() {
-  readonly stashdir_list_file=$(mktemp 'helm-git.stash.XXXXXX')
+  readonly stashdir_list_file=$(mktemp "$TMPDIR/helm-git.stash.XXXXXX")
   stashdir_clean_skip=$debug
 
   if [ $debug = 0 ]; then
@@ -51,7 +51,7 @@ stashdir_init() {
 stashdir_new() {
   _comment="$1"
 
-  new_dir=$(mktemp -d 'helm-git.XXXXXX')
+  new_dir=$(mktemp -d "$TMPDIR/helm-git.XXXXXX")
   echo "$new_dir" >> "$stashdir_list_file"
   echo "$new_dir"
   if [ $debug = 1 ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -1214,6 +1223,12 @@
         "readable-stream": "^2.0.4"
       }
     },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
@@ -1931,24 +1946,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-      "dev": true
-    },
-    "jest-validate": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-      "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^23.6.0"
-      }
-    },
     "js-yaml": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
@@ -2033,12 +2030,6 @@
         "flush-write-stream": "^1.0.2"
       }
     },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
-    },
     "linez": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/linez/-/linez-4.1.4.tgz",
@@ -2050,15 +2041,15 @@
       }
     },
     "lint-staged": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.0.tgz",
-      "integrity": "sha512-yfSkyJy7EuVsaoxtUSEhrD81spdJOe/gMTGea3XaV7HyoRhTb9Gdlp6/JppRZERvKSEYXP9bjcmq6CA5oL2lYQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.3.tgz",
+      "integrity": "sha512-6TGkikL1B+6mIOuSNq2TV6oP21IhPMnV8q0cf9oYZ296ArTVNcbFh1l1pfVOHHbBIYLlziWNsQ2q45/ffmJ4AA==",
       "dev": true,
       "requires": {
         "@iamstarkov/listr-update-renderer": "0.4.1",
         "chalk": "^2.3.1",
         "commander": "^2.14.1",
-        "cosmiconfig": "5.0.6",
+        "cosmiconfig": "^5.0.2",
         "debug": "^3.1.0",
         "dedent": "^0.7.0",
         "del": "^3.0.0",
@@ -2067,7 +2058,6 @@
         "g-status": "^2.0.2",
         "is-glob": "^4.0.0",
         "is-windows": "^1.0.2",
-        "jest-validate": "^23.5.0",
         "listr": "^0.14.2",
         "lodash": "^4.17.5",
         "log-symbols": "^2.2.0",
@@ -2079,20 +2069,10 @@
         "please-upgrade-node": "^3.0.2",
         "staged-git-files": "1.1.2",
         "string-argv": "^0.0.2",
-        "stringify-object": "^3.2.2"
+        "stringify-object": "^3.2.2",
+        "yup": "^0.26.10"
       },
       "dependencies": {
-        "cosmiconfig": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-          "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
-          "dev": true,
-          "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0"
-          }
-        },
         "is-glob": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -2912,20 +2892,16 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "pretty-format": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "property-expr": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
+      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
       "dev": true
     },
     "pseudomap": {
@@ -2992,6 +2968,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -3125,9 +3107,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -3217,9 +3199,9 @@
       "dev": true
     },
     "shellcheck": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-0.1.0.tgz",
-      "integrity": "sha512-/ACVouhFqVnwU2x1GxVicxvplOu9QeWihJIMApkVbdYmvbl1iTf2rSo/dXzDDadF8n+zbqYn3v981LUvMj86OA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-0.2.3.tgz",
+      "integrity": "sha512-MuKlNkBe4IK67VLpKuS3c1FoRVJwGziYfn/ZP2EPFLymwaulbMqGkY1a0R/1b9dcUaR5ZMJoT7u7O4L78PPVVg==",
       "dev": true
     },
     "sigmund": {
@@ -3613,6 +3595,12 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
+    "synchronous-promise": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.6.tgz",
+      "integrity": "sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==",
+      "dev": true
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -3763,6 +3751,12 @@
       "requires": {
         "bignumber.js": "^2.4.0"
       }
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
@@ -4099,6 +4093,20 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yup": {
+      "version": "0.26.10",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
+      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "7.0.0",
+        "fn-name": "~2.0.1",
+        "lodash": "^4.17.10",
+        "property-expr": "^1.5.0",
+        "synchronous-promise": "^2.0.5",
+        "toposort": "^2.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "bats": "github:josegonzalez/bats-core#723a1fa83524f7e2b120eddd2ca5358ca5706b4f",
     "eclint": "^2.8.1",
     "husky": "^1.3.1",
-    "lint-staged": "^8.1.0",
-    "shellcheck": "^0.1.0"
+    "lint-staged": "^8.1.3",
+    "shellcheck": "^0.2.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- support for BSD sed: switch from `-r` to `-E` option
- support for BSD mktemp: drop `-p` option as it doesn't look to be needed 

Fixes #4 

Try it:
```sh
helm plugin remove helm-git
helm plugin install https://github.com/aslafy-z/helm-git --version fix/osx-compat
``` 