### PR TITLE
fix: sometimes some tags can't be checked out

### DIFF
--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -65,14 +65,13 @@ git_checkout() {
   cd "$_target_path" >&2
   git init --quiet
   git remote add origin "$_git_repo" >&2
-  # git fetch --tags >&2
   if [ "$_sparse" = "1" ]; then
     git config core.sparseCheckout true
     [ -n "$_git_path" ] && echo "$_git_path/*" >.git/info/sparse-checkout
     git pull --quiet --depth 1 origin "$_git_ref" >&2 || error \
       error "Unable to sparse-checkout. Check your Git ref ($git_ref) and path ($git_path)."
   else
-    git fetch --quiet origin >&2 || error \
+    git fetch --tags --quiet origin >&2 || error \
       error "Unable to fetch remote. Check your Git url."
     git checkout --quiet "$git_ref" >&2 || error \
       error "Unable to checkout ref. Check your Git ref ($git_ref)."


### PR DESCRIPTION
sometimes we get the following error for existing tags:

```
error: pathspec 'v0.0.2-alpha.7' did not match any file(s) known to git
Error in plugin 'helm-git': error Unable to checkout ref. Check your Git ref (v0.0.2-alpha.7).
Error: looks like "git+https://******:*******@gitlab.example.com/group/project.git@deploy?ref=v0.0.2-alpha.7&sparse=0"
```

`git tag -l` shows the tag `v0.0.2-alpha.7`

To fix this just adding `--tags` to the fetch-command