### PR TITLE
Run GH actions on external pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,10 @@
 name: lint
 
 on:
-  push
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: test
 
 on:
-  push
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
To avoid duplicate runs on internal pull request, actions should only run on push master.