### PR TITLE
Check if file is file before cat-ing

### DIFF
--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -226,16 +226,12 @@ main() {
   readonly git_sub_path=$git_sub_path
   git_checkout "$git_sparse" "$git_root_path" "$git_repo" "$git_ref" "$git_path" ||
     error "Error while git_sparse_checkout"
-    
-  case "$helm_file" in
-  index.yaml) ;;
-  *.tgz) ;;
-  *)
+  
+  if [[ -f $helm_file ]]
+  then
     # value files
     cat "$git_path/$helm_file"
-    return
-    ;;
-  esac
+  fi
 
   helm_target_path="$(mktemp -d "$TMPDIR/helm-git.XXXXXX")"
   readonly helm_target_path=$helm_target_path


### PR DESCRIPTION
This will try to cat a file as it uses `*` which matches everything. Using `-f` will check that it is a file before we try to cat it.

```
aaron.george:~/Library/Caches/helm/plugins/https-github.com-aslafy-z-helm-git AWS:none> ./helm-gi
t "" "" "" "git+https://github.com/jetstack/cert-manager@deploy/charts"     
https://github.com/jetstack/cert-manager@deploy/charts
charts
Warning in plugin 'helm-git': git_ref is empty, defaulted to 'master'. Prefer to pin GIT ref in URI.
cat: deploy/charts: Is a directory
```