### PR TITLE
Updates the stable repo during a helm init

### DIFF
--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -93,7 +93,7 @@ helm_init() {
   if ! helm_check; then return 1; fi
   if ! helm_v2; then return 0; fi
   _helm_home=$1
-  "$HELM_BIN" init --client-only --home "$_helm_home" >/dev/null
+  "$HELM_BIN" init --client-only --stable-repo-url https://charts.helm.sh/stable --home "$_helm_home" >/dev/null
   HELM_HOME=$_helm_home
   export HELM_HOME
 }


### PR DESCRIPTION
* Helm version 2 still requires a stable repo to be set
* This repo location was deprecated, so let's get this updated to the
  new location
* Luckily we can set this during the init command using the
  `stable-repo-url` flag