### PR TITLE
feat: &package=0 skips helm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Here's the Git urls format, followed by examples:
     git+ssh://git@github.com/jetstack/cert-manager@deploy/charts?ref=v0.6.2&sparse=1
     git+ssh://git@github.com/jetstack/cert-manager@deploy/charts?ref=v0.6.2
     git+https://github.com/istio/istio@install/kubernetes/helm?ref=1.5.4&sparse=0&depupdate=0
+    git+https://github.com/bitnami/charts@bitnami/wordpress?depupdate=0?ref=master&sparse=0&depupdate=0&package=0
 
 Add your repository:
 
@@ -77,6 +78,7 @@ Pulling value files:
 `ref`|Set git ref to a branch or tag. Works also for commits with `sparse=0`|`master`
 `sparse`|Set git strategy to sparse. Will try to fetch only the needed commits for the target path|`1`
 `depupdate`|Run `helm dependency update` on the retrieved chart|`1`
+`package`|Run `helm package` on the retrieved chart|`1`
 
 ### Note on Git authentication
 

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -208,8 +208,11 @@ main() {
   helm_depupdate=$(echo "$_raw_uri" | sed '/^.*depupdate=\([^&#]*\).*$/!d;s//\1/')
   [ -z "$helm_depupdate" ] && helm_depupdate=1
 
-  debug "repo: $git_repo ref: $git_ref path: $git_path file: $helm_file sparse: $git_sparse depupdate: $helm_depupdate"
-  readonly helm_repo_uri="git+$git_repo@$git_path?ref=$git_ref&sparse=$git_sparse&depupdate=$helm_depupdate"
+  helm_package=$(echo "$_raw_uri" | sed '/^.*package=\([^&#]*\).*$/!d;s//\1/')
+  [ -z "$helm_package" ] && helm_package=1
+
+  debug "repo: $git_repo ref: $git_ref path: $git_path file: $helm_file sparse: $git_sparse depupdate: $helm_depupdate package: $helm_package"
+  readonly helm_repo_uri="git+$git_repo@$git_path?ref=$git_ref&sparse=$git_sparse&depupdate=$helm_depupdate&package=$helm_package"
   debug "helm_repo_uri: $helm_repo_uri"
 
   # Setup cleanup trap
@@ -268,8 +271,10 @@ main() {
         helm_dependency_update "$chart_path" ||
           error "Error while helm_dependency_update"
       fi
+      if [ "$helm_package" = "1" ]; then
       helm_package "$helm_target_path" "$chart_path" "$chart_name" ||
         error "Error while helm_package"
+      fi
     done
   }
 

--- a/tests/05-helm-cli.bats
+++ b/tests/05-helm-cli.bats
@@ -69,3 +69,14 @@ load 'test-helper'
     run grep istio-1.5.4 "$HELM_HOME/repository/repositories.yaml"
     [ -n "$output" ]
 }
+
+@test "helm_cli repo_add wp-cff9c65 depupdate=0 package=0" {
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run helm plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run helm repo add wp-cff9c65 'git+https://github.com/bitnami/charts@bitnami/wordpress?depupdate=0?ref=cff9c65&sparse=0&depupdate=0&package=0'
+    [ $status = 0 ]
+    run grep wp-cff9c65 "$HELM_HOME/repository/repositories.yaml"
+    [ -n "$output" ]
+}


### PR DESCRIPTION
Hi there, thanks for this cool project!
Here dropping this feature from a use case that happened to me earlier today: when fetching a chart from a repo containing multiple charts, you don't want to package other charts with unresolved dependencies from other repos. Another use case could be pulling a chart with conditional dependencies.