### PR TITLE
feat: Cache git repos and/or helm charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         helm: ['2.17.0', '3.4.2', '3.7.1']
     env:
-      FIXTURES_GIT_BRANCH: ${{ github.base_ref || github.ref_name }}
+      FIXTURES_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         helm: ['2.17.0', '3.4.2', '3.7.1']
     env:
-      FIXTURES_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+      FIXTURES_GIT_BRANCH: ${{ github.base_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Pulling value files:
 --------|---------------|-----------
 `HELM_GIT_HELM_BIN`|Path to the `helm` binary. If not set, `$HELM_BIN` will be used|`helm`
 `HELM_GIT_DEBUG`|Increase `helm-git` log level to maximum|`0`
+`HELM_GIT_REPO_CACHE`|Path to use as a git repository cache to avoid fetching repos more than once or offline usage|`"" #cache disabled`
+`HELM_GIT_CHART_CACHE`|Path to use as a helm chart cache to avoid re-packaging or re-indexing charts|`"" #cache disabled`
 
 ### Arguments
 

--- a/README.md
+++ b/README.md
@@ -64,23 +64,23 @@ Pulling value files:
 
     helm install . -f git+https://github.com/aslafy-z/helm-git@tests/fixtures/example-chart/values.yaml
 
-### Environment
+### Environment variables
 
 **name**|**description**|**default**
 --------|---------------|-----------
-`HELM_GIT_HELM_BIN`|Path to the `helm` binary. If not set, `$HELM_BIN` will be used|`helm`
-`HELM_GIT_DEBUG`|Increase `helm-git` log level to maximum|`0`
-`HELM_GIT_REPO_CACHE`|Path to use as a git repository cache to avoid fetching repos more than once or offline usage|`"" #cache disabled`
-`HELM_GIT_CHART_CACHE`|Path to use as a helm chart cache to avoid re-packaging or re-indexing charts|`"" #cache disabled`
+`HELM_GIT_HELM_BIN`|Path to the `helm` binary. If not set, `$HELM_BIN` will be used.|`helm`
+`HELM_GIT_DEBUG`|Setting this value to `1` increases `helm-git` log level to the maximum. |`0`
+`HELM_GIT_REPO_CACHE`|Path to use as a Git repository cache to avoid fetching repos more than once. If empty, caching of Git repositories is disabled.|`""`
+`HELM_GIT_CHART_CACHE`|Path to use as a Helm chart cache to avoid re-packaging/re-indexing charts. If empty, caching of Helm charts is disabled.|`""`
 
 ### Arguments
 
 **name**|**description**|**default**
 --------|---------------|-----------
-`ref`|Set git ref to a branch or tag. Works also for commits with `sparse=0`|`master`
-`sparse`|Set git strategy to sparse. Will try to fetch only the needed commits for the target path|`1`
-`depupdate`|Run `helm dependency update` on the retrieved chart|`1`
-`package`|Run `helm package` on the retrieved chart|`1`
+`ref`|Set git ref to a branch or tag. Also works for commits with `sparse=0`.|`master`
+`sparse`|Set git strategy to sparse. Will try to fetch only the needed commits for the target path. If set to `0`, default git strategy will be used.|`1`
+`depupdate`|Run `helm dependency update` on the retrieved chart. If set to `0`, this step is skipped.|`1`
+`package`|Run `helm package` on the retrieved chart. If set to `0`, this step is skipped.|`1`
 
 ### Note on Git authentication
 

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -12,7 +12,7 @@ readonly error_invalid_prefix="Git url should start with '$url_prefix'. Please c
 readonly error_invalid_protocol="Protocol not allowed, it should match one of theses: $allowed_protocols."
 
 debug=0
-if [ "$HELM_GIT_DEBUG" = "1" ]; then
+if [ "${HELM_GIT_DEBUG:-}" = "1" ]; then
   debug=1
 fi
 

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -55,7 +55,7 @@ git_try() {
 }
 
 #git_cache_intercept(git_repo, git_ref)
-git_cache_intercept(){
+git_cache_intercept() {
     _git_repo="${1?Missing git_repo as first parameer}"
     _git_ref="${2?Missing git_ref as second parameter}"
     debug "Trying to intercept for ${_git_repo}#${_git_ref}"

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -61,9 +61,9 @@ git_cache_intercept(){
     _git_repo="${1?Missing git_repo as first parameer}"
     _git_ref="${2?Missing git_ref as second parameter}"
     debug "Trying to intercept for ${_git_repo}#${_git_ref}"
-    repo_tokens=($(echo "${_git_repo}" | sed -E -e 's/[^/]+\/\/([^@]*@)?([^/]+)\/(.+)$/\2 \3/' -e 's/\.git$//g' ))
-    repo_host="${repo_tokens[0]}"
-    repo_repo="${repo_tokens[1]}"
+    repo_tokens=$(echo "${_git_repo}" | sed -E -e 's/[^/]+\/\/([^@]*@)?([^/]+)\/(.+)$/\2 \3/' -e 's/\.git$//g' )
+    repo_host=$(echo "${repo_tokens}" | cut -d " " -f1)
+    repo_repo=$(echo "${repo_tokens}" | cut -d " " -f2)
     if [ ! -d "${HELM_GIT_REPO_CACHE}" ]; then
         debug "HELM_GIT_REPO_CACHE:${HELM_GIT_REPO_CACHE} is not a directory, cannot cache"
         echo "${_git_repo}"

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -54,8 +54,6 @@ git_try() {
   GIT_TERMINAL_PROMPT=0 git ls-remote "$_git_repo" --refs >&2 || return 1
 }
 
-
-
 #git_cache_intercept(git_repo, git_ref)
 git_cache_intercept(){
     _git_repo="${1?Missing git_repo as first parameer}"

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -2,7 +2,7 @@
 
 # See Helm plugins documentation: https://docs.helm.sh/using_helm/#downloader-plugins
 
-set -euo pipefail
+set -eu
 
 readonly bin_name="helm-git"
 readonly allowed_protocols="https http file ssh"

--- a/tests/06-helm-git-cache.bats
+++ b/tests/06-helm-git-cache.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load 'test-helper'
+
+
+@test "helm_cli fetch index.yaml and ensure repo is cached" {
+    enable_repo_cache
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run time "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/index.yaml?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "First time I see https://github.com/jetstack/cert-manager"
+    run time "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/index.yaml?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "https://github.com/jetstack/cert-manager exists in cache"
+}
+
+@test "helm_cli fetch cert-manager-v0.5.2.tgz and ensure repo is cached" {
+    enable_repo_cache
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "First time I see https://github.com/jetstack/cert-manager"
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "https://github.com/jetstack/cert-manager exists in cache"
+    run stat "$HELM_GIT_OUTPUT/cert-manager-v0.5.2.tgz"
+    [ $status = 0 ]
+}
+
+@test "helm_cli fetch cert-manager-v0.5.2.tgz and ensure chart is cached" {
+    enable_chart_cache
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    echo "$output" | grep "Helm request not found in cache"
+    [ $status = 0 ]
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "Returning cached helm request"
+    run stat "$HELM_GIT_OUTPUT/cert-manager-v0.5.2.tgz"
+    [ $status = 0 ]
+}

--- a/tests/test-helper.bash
+++ b/tests/test-helper.bash
@@ -21,9 +21,25 @@ setup() {
   export HELM_HOME
   export XDG_DATA_HOME
   export HELM_GIT_OUTPUT
+
+  # Ensure we do not pollute runners helm repo list etc...
+  HELM_CACHE_HOME=$(mktemp -d "$BATS_TMPDIR/helm-git.helm-cache-home.XXXXXX")
+  HELM_CONFIG_HOME=$(mktemp -d "$BATS_TMPDIR/helm-git.helm-cache-home.XXXXXX")
+
+  export HELM_CACHE_HOME
+  export HELM_CONFIG_HOME
 }
 
 teardown() {
   rm -rf "$HELM_HOME"
   rm -rf "$HELM_GIT_OUTPUT"
+}
+
+enable_chart_cache() {
+    HELM_GIT_CHART_CACHE=$(mktemp -d "$BATS_TMPDIR/helm-git.chart-cache.XXXXXX")
+    export HELM_GIT_CHART_CACHE
+}
+enable_repo_cache() {
+    HELM_GIT_REPO_CACHE=$(mktemp -d "$BATS_TMPDIR/helm-git.repo-cache.XXXXXX")
+    export HELM_GIT_REPO_CACHE
 }


### PR DESCRIPTION
While using helm-git in a manifest generation pipeline I have noticed a lot of redundant git fetches, helm indexes and helm packages.

With this PR, currently using it, 2 new behaviours become available.
* Cache git repos, by setting HELM_GIT_REPO_CACHE env to an existing folder it ensures repos are only fetched once per ref, it can also be used for offline generation by copying the cache as an artifact
* Cache helm charts, by setting HELM_GIT_CHART_CACHE env to an existing folder it ensures charts are only generated once, this speeds up manifest generating pipelines by a lot if git provided charts are reused in many places.

Even just `rm -rf caches && ./generate_manifests` is orders of magnitude faster for us when enabling both caches