### PR TITLE
fix: _uri_scheme: is read only

### DIFF
--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -245,11 +245,11 @@ main() {
   _uri_scheme=$(echo "$_raw_uri" | sed -Ene "s'$URI_REGEX'\1'p")
   readonly _uri_scheme
   _uri_authority=$(echo "$_raw_uri" | sed -Ene "s'$URI_REGEX'\3'p")
-  readonly _uri_scheme
+  readonly _uri_authority
   _uri_path=$(echo "$_raw_uri" | sed -Ene "s'$URI_REGEX'\8'p")
-  readonly _uri_scheme
+  readonly _uri_path
   _uri_query=$(echo "$_raw_uri" | sed -Ene "s'$URI_REGEX'\9'p")
-  readonly _uri_scheme
+  readonly _uri_query
 
   git_scheme=$(echo "$_uri_scheme" | sed -e 's/^git+//')
   readonly git_scheme="$git_scheme"


### PR DESCRIPTION
In helm-secrets, I'm running the [CI](https://github.com/jkroepke/helm-secrets/actions/runs/4269445308/jobs/7432630717) with [posh](https://manpages.ubuntu.com/manpages/focal/man1/posh.1.html) shell. 

On that shell, I'm getting error like this while running helm-git:

 _uri_scheme: is read only

This PR should fixes this.