### PR TITLE
fix(helm-git): multiple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Pulling value files:
 **name**|**description**|**default**
 --------|---------------|-----------
 `HELM_GIT_HELM_BIN`|Path to the `helm` binary. If not set, `$HELM_BIN` will be used.|`helm`
-`HELM_GIT_DEBUG`|Setting this value to `1` increases `helm-git` log level to the maximum. |`0`
+`HELM_GIT_DEBUG`|Setting this value to `1` increases `helm-git` log level. |`0`
+`HELM_GIT_TRACE`|Setting this value to `1` increases `helm-git` log level to the maximum. |`0`
 `HELM_GIT_REPO_CACHE`|Path to use as a Git repository cache to avoid fetching repos more than once. If empty, caching of Git repositories is disabled.|`""`
 `HELM_GIT_CHART_CACHE`|Path to use as a Helm chart cache to avoid re-packaging/re-indexing charts. If empty, caching of Helm charts is disabled.|`""`
 


### PR DESCRIPTION
# Why

I was trying this awesome plugin, but found some issues with the way I wanted to use it. I want to be able to use packaged helm charts from a branch, the charts and `index.yaml` might be in the root folder of the repository and this was not allowed.

Also had to set the `url` to `git+ssh://git@github.com/org/repository/path/package-x.x.x.tgz?ref=branch&sparse=0&depupdate=1&package=0` in `index.yaml` on all the packages for this work.

# What

1. add trace: makes it easier to troubleshoot
1. allow using repository root folder: there was an assumption that there would be a path with `@`
1. ensure we have the latest from ref: when using `HELM_GIT_REPO_CACHE` the branch wouldn't be updated, probably the initial intention was to only use tags
1. lint file: shellcheck