### PR TITLE
feat: Add `HELM_GIT_CHART_CACHE_STRATEGY` variable to customize chart caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Pulling value files:
 `HELM_GIT_TRACE`|Setting this value to `1` increases `helm-git` log level to the maximum and keeps temporary dirs at shutdown. |`0`
 `HELM_GIT_REPO_CACHE`|Path to use as a Git repository cache to avoid fetching repos more than once. If empty, caching of Git repositories is disabled.|`""`
 `HELM_GIT_CHART_CACHE`|Path to use as a Helm chart cache to avoid re-packaging/re-indexing charts. If empty, caching of Helm charts is disabled.|`""`
+`HELM_GIT_CHART_CACHE_STRATEGY`|Strategy to use when caching charts. If `repo` then all charts from the same repo will use the same cache. If `chart`, caching will only build single chart for each chart if `package` is `1`. Any other values preserves the default behavior: each chart has its own cache and all packages are built every time if `package` is `1`.|`""`
 
 ### Arguments
 

--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -465,7 +465,7 @@ main() {
   chart_search_root="$git_sub_path"
 
   if [ "$helm_chart_name" != "index.yaml" ] && [ "$cache_charts_enabled" = "1" ] && [ "$cache_charts_strategy" = "chart" ]; then
-    chart_search=$(find "$chart_search_root" -maxdepth 2 -name "Chart.yaml" -exec grep -l "name:\s$helm_chart_name" {} +)
+    chart_search=$(find "$chart_search_root" -maxdepth 2 -name "Chart.yaml" -exec grep -lE "name:\s*('|\")?${helm_chart_name}('|\")?(\s+|$)" {} +)
   else
     chart_search=$(find "$chart_search_root" -maxdepth 2 -name "Chart.yaml" -print)
   fi

--- a/tests/06-helm-git-cache.bats
+++ b/tests/06-helm-git-cache.bats
@@ -48,3 +48,45 @@ load 'test-helper'
     run stat "$HELM_GIT_OUTPUT/cert-manager-v0.5.2.tgz"
     [ $status = 0 ]
 }
+
+@test "helm_cli fetch index.yaml and ensure chart cert-manager-v0.5.2.tgz is cached if strategy=repo" {
+    enable_chart_cache
+    set_chart_cache_strategy "repo"
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/index.yaml?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "Helm request not found in cache"
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/jetstack/cert-manager@contrib/charts/cert-manager-v0.5.2.tgz?ref=v0.5.2"
+    [ $status = 0 ]
+    echo "$output" | grep "Returning cached helm request"
+    run stat "$HELM_GIT_OUTPUT/cert-manager-v0.5.2.tgz"
+    [ $status = 0 ]
+}
+
+@test "helm_cli fetch gateway and ensure only single chart is packaged" {
+    enable_chart_cache
+    run helm_init "$HELM_HOME"
+    [ $status = 0 ]
+    run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
+    [ $status = 0 ]
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@manifests/charts/gateway-1.0.0.tgz?ref=1.24.2"
+    [ $status = 0 ]
+    echo "$output" | grep "Helm request not found in cache"
+    run stat "$HELM_GIT_OUTPUT/gateway-1.0.0.tgz"
+    [ $status = 0 ]
+    run bats_pipe ls -1 "$HELM_GIT_CHART_CACHE"/*/* \| grep -v index.yaml \| wc -l \| awk '{print $1}'
+    [ "$output" -gt "1" ]
+    run rm -rf "$HELM_GIT_CHART_CACHE"/*/*
+    set_chart_cache_strategy "chart"
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@manifests/charts/gateway-1.0.0.tgz?ref=1.24.2"
+    [ $status = 0 ]
+    echo "$output" | grep "Helm request not found in cache"
+    run stat "$HELM_GIT_OUTPUT/gateway-1.0.0.tgz"
+    [ $status = 0 ]
+    run bats_pipe ls -1 "$HELM_GIT_CHART_CACHE"/*/* \| grep -v index.yaml \| wc -l \| awk '{print $1}'
+    [ "$output" = "1" ]
+}
+

--- a/tests/06-helm-git-cache.bats
+++ b/tests/06-helm-git-cache.bats
@@ -72,19 +72,19 @@ load 'test-helper'
     [ $status = 0 ]
     run "$HELM_BIN" plugin install "$HELM_GIT_DIRNAME"
     [ $status = 0 ]
-    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@manifests/charts/gateway-1.0.0.tgz?ref=1.24.2"
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@install/kubernetes/helm/istio-1.1.0.tgz?ref=1.1.0"
     [ $status = 0 ]
     echo "$output" | grep "Helm request not found in cache"
-    run stat "$HELM_GIT_OUTPUT/gateway-1.0.0.tgz"
+    run stat "$HELM_GIT_OUTPUT/istio-1.1.0.tgz"
     [ $status = 0 ]
     run bats_pipe ls -1 "$HELM_GIT_CHART_CACHE"/*/* \| grep -v index.yaml \| wc -l \| awk '{print $1}'
     [ "$output" -gt "1" ]
     run rm -rf "$HELM_GIT_CHART_CACHE"/*/*
     set_chart_cache_strategy "chart"
-    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@manifests/charts/gateway-1.0.0.tgz?ref=1.24.2"
+    run "$HELM_BIN" fetch -d "$HELM_GIT_OUTPUT" "git+https://github.com/istio/istio@install/kubernetes/helm/istio-1.1.0.tgz?ref=1.1.0"
     [ $status = 0 ]
     echo "$output" | grep "Helm request not found in cache"
-    run stat "$HELM_GIT_OUTPUT/gateway-1.0.0.tgz"
+    run stat "$HELM_GIT_OUTPUT/istio-1.1.0.tgz"
     [ $status = 0 ]
     run bats_pipe ls -1 "$HELM_GIT_CHART_CACHE"/*/* \| grep -v index.yaml \| wc -l \| awk '{print $1}'
     [ "$output" = "1" ]

--- a/tests/test-helper.bash
+++ b/tests/test-helper.bash
@@ -50,3 +50,7 @@ enable_repo_cache() {
     HELM_GIT_REPO_CACHE=$(mktemp -d "$BATS_TMPDIR/helm-git.repo-cache.XXXXXX")
     export HELM_GIT_REPO_CACHE
 }
+set_chart_cache_strategy() {
+    HELM_GIT_CHART_CACHE_STRATEGY="$1"
+    export HELM_GIT_CHART_CACHE_STRATEGY
+}


### PR DESCRIPTION
Fixes #318 

This MR allows cache customization via `HELM_GIT_CHART_CACHE_STRATEGY` variable.

The default behavior causes N^2 builds if package=1 and you deploy multiple chats from the same repo.

There are 2 ways to fix it:

If you set `HELM_GIT_CHART_CACHE_STRATEGY` to `repo`, then every chart will reuse the same cache from the repo. That's done by using `helm_repo_uri` as the source for request_hash.
If you set `HELM_GIT_CHART_CACHE_STRATEGY` to `chart`, then every chart will have only single chart packaged, not all repository.

Other values preserve the old behavior.

I'm not changing the default behavior since it can break existing setups and requires major version update according to SemVer.

One thing to consider is if we really need both strategies. If no, then we can only leave 1 and change the variable to boolean one.

In my opinion "repo" strategy is the right way to cache in all cases, but I don't have the bigger picture of how the plugin is used by others.

Tests cover both of the strategies usage.

For repo we ensure that cache is reused if we clone repo first and then try to fetch a chart.
For chart we ensure that without strategy all charts are built (> 1), with it turned on only a single one.