### PR TITLE
fix: update helm_v2 detection to support v4

### DIFF
--- a/helm-git-plugin.sh
+++ b/helm-git-plugin.sh
@@ -222,7 +222,9 @@ git_checkout() {
 
 # helm_v2()
 helm_v2() {
-  "$HELM_BIN" version -c --short | grep -q v2
+  # --client is ignored in v3
+  # '.Client.SemVer' fails > v2
+  "$HELM_BIN" version --client --template '{{.Client.SemVer}}' >/dev/null 2>&1
 }
 
 # helm_init(helm_home)


### PR DESCRIPTION
v4 dropped the `helm version --client` flag. It was ignored in v3.

Instead of using `--short --client` and compare version number:
- use a only-v2 flag (`--template `{{.Client.SemVer}}`)
- hide all errors
- check for status

It success only with v2